### PR TITLE
Added MandelBLOCK, a blocky Mandelbrot set example

### DIFF
--- a/examples/mandelblock/mandelblock.bas
+++ b/examples/mandelblock/mandelblock.bas
@@ -31,7 +31,7 @@ for py! = 0 to 24
       xt% = x% * x% - y% * y% + xz%
       y% = 2.0 * x% * y% + yz%
       x% = xt%
-      i! = i! + 1
+      inc i!
     endwhile
     poke r + px!, i!
   next px!


### PR DESCRIPTION
inspired by Matt Hefferman's YT video "8-BIT battle royale" (https://www.youtube.com/watch?v=DC5wi6iv9io&t=1687s)
code based on Wikipedia's Mandelbrot set pseudocode (https://en.wikipedia.org/wiki/Mandelbrot_set)
with speed optimizations suggested by Csaba Fekete, creator of XC-Basic.